### PR TITLE
Rename methods and move the transaction option to the main DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # Caze
 
-This is a simple DSL to easily define use cases.
-The main propose is to avoid the verbose declarations of
-use cases entry points inside the main project file.
+This is a simple DSL to easily declare use cases as entry points of a gem.
+The purpose is to avoid the verbose declarations.
 
 ## Usage
 
@@ -28,12 +27,35 @@ require 'caze'
 module Project
   include Caze
 
-  define_use_cases sum:      UseCases::Sum,
-                   subtract: UseCases::Subtract
+  has_use_case sum:      UseCases::Sum,
+  has_use_case subtract: UseCases::Subtract
 end
 ```
 
-And in the `UseCases::Sum` instead of this:
+## Using transactions
+
+You can use transactions in your use cases by providing a `transaction_handler`
+in your project entry point. The only method that transaction handler should
+respond is `#transaction`.
+
+```ruby
+Project.transaction_handler = ActiveRecord::Base
+```
+
+While declaring which use cases your app has, you can set the option
+`transactional` to `true`.
+
+```ruby
+  has_use_case wow: UseCases::Wow, transactional: true
+```
+
+Note that the transaction handler must implement `#transaction` and
+return the value inside the block. It will also be responsible for handle errors
+and rollback if necessary.
+
+## Exporting instance methods as class methods
+
+Inside the use case classes you can use the `.export` method, so in the `UseCases::Sum` instead of this:
 
 ```ruby
 module Project
@@ -79,32 +101,15 @@ module Project
 end
 ```
 
-The usage is like was before:
+The `as` param, tells how the class method must be named,
+if it is not passed the class method will have the of the instance method.
+
+
+With this you can call your project use cases without the need to know its internals:
 
 ```ruby
 Project.sum(4, 2) # This will call sum inside the use case `UseCases::Sum`
 ```
-
-## Using transactions
-
-You can use transactions in your use cases by providing a `transaction_handler`
-in your project entry point. The only method that transaction handler should
-respond is `#transaction`.
-
-```ruby
-Project.transaction_handler = ActiveRecord::Base
-```
-
-Inside your use case, you need to define the entry point with the flag
-`use_transaction` set to `true`.
-
-```ruby
-export :foo, use_transaction: true
-```
-
-Note that the transaction handler should implement `#transaction` and
-return the value inside the block. It will also be responsible for handle errors
-and rollback if necessary.
 
 # Apache License 2.0
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caze
 
-This is a simple DSL to easily declare use cases as entry points of a gem.
+This is a simple DSL to declare use cases as entry points of a module.
 The purpose is to avoid the verbose declarations.
 
 ## Usage
@@ -35,7 +35,7 @@ end
 ## Using transactions
 
 You can use transactions in your use cases by providing a `transaction_handler`
-in your project entry point. The only method that transaction handler should
+in your module. The only method that transaction handler should
 respond is `#transaction`.
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ module Project
 end
 ```
 
-You can define the entry point (the class method) with `define_entry_point`:
+You can define a class method based on an instance method with `export`:
 
 ```ruby
 module Project
@@ -64,7 +64,7 @@ module Project
     class Foo
       include Caze
 
-      define_entry_point :sum, as: :execute
+      export :sum, as: :execute
 
       def initialize(x, y)
         @x = x
@@ -99,7 +99,7 @@ Inside your use case, you need to define the entry point with the flag
 `use_transaction` set to `true`.
 
 ```ruby
-define_entry_point :foo, use_transaction: true
+export :foo, use_transaction: true
 ```
 
 Note that the transaction handler should implement `#transaction` and

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -11,35 +11,31 @@ module Caze
     attr_accessor :transaction_handler
 
     def define_use_cases(use_cases)
-      use_cases.each_pair do |use_case_name, use_case_class|
-        main_module = self
+      use_cases.each_pair do |use_case_name, params|
+        use_case_class = params.fetch(:use_case)
 
-        # Define a reference to the parent module
-        # in order to be able to use the transaction handler.
-        use_case_class.define_singleton_method(:parent_module, ->() { main_module })
+        within_transaction  = params.fetch(:within_transaction) { false }
 
         define_singleton_method(use_case_name, Proc.new { |*args|
-          use_case_class.send(use_case_name, *args)
+          if within_transaction
+            handler = self.transaction_handler
+
+            raise NoTransactionMethodError, "This action should be executed inside a transaction. But no transaction handler was configured." unless handler
+
+            handler.transaction { use_case_object.send(method_name) }
+          else
+            use_case_class.send(use_case_name, *args)
+          end
         })
       end
     end
 
     def export(method_name, options = {})
       method_to_define = options.fetch(:as) { method_name }
-      use_transaction  = options.fetch(:use_transaction) { false }
 
       define_singleton_method(method_to_define, Proc.new { |*args|
         use_case_object = args.empty? ? new : new(*args)
-
-        if use_transaction
-          handler = parent_module.transaction_handler
-
-          raise NoTransactionMethodError, "This action should be executed inside a transaction. But no transaction handler was configured." unless handler
-
-          handler.transaction { use_case_object.send(method_name) }
-        else
-          use_case_object.send(method_name)
-        end
+        use_case_object.send(method_name)
       })
     end
   end

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -24,7 +24,7 @@ module Caze
       end
     end
 
-    def define_entry_point(method_name, options = {})
+    def export(method_name, options = {})
       method_to_define = options.fetch(:as) { method_name }
       use_transaction  = options.fetch(:use_transaction) { false }
 

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -10,7 +10,7 @@ module Caze
   module ClassMethods
     attr_accessor :transaction_handler
 
-    def define_use_case(use_case_name, use_case_class, options = {})
+    def has_use_case(use_case_name, use_case_class, options = {})
       transactional  = options.fetch(:transactional) { false }
 
       define_singleton_method(use_case_name, Proc.new { |*args|

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -10,16 +10,16 @@ module Caze
   module ClassMethods
     attr_accessor :transaction_handler
 
-    def define_use_cases(use_cases)
-      use_cases.each_pair do |use_case_name, use_case_class|
+    def define_entry_points(entry_points)
+      entry_points.each_pair do |entry_point_name, entry_point_class|
         main_module = self
 
         # Define a reference to the parent module
         # in order to be able to use the transaction handler.
-        use_case_class.define_singleton_method(:parent_module, ->() { main_module })
+        entry_point_class.define_singleton_method(:parent_module, ->() { main_module })
 
-        define_singleton_method(use_case_name, Proc.new { |*args|
-          use_case_class.send(use_case_name, *args)
+        define_singleton_method(entry_point_name, Proc.new { |*args|
+          entry_point_class.send(entry_point_name, *args)
         })
       end
     end
@@ -29,16 +29,16 @@ module Caze
       use_transaction  = options.fetch(:use_transaction) { false }
 
       define_singleton_method(method_to_define, Proc.new { |*args|
-        use_case_object = args.empty? ? new : new(*args)
+        entry_point_object = args.empty? ? new : new(*args)
 
         if use_transaction
           handler = parent_module.transaction_handler
 
           raise NoTransactionMethodError, "This action should be executed inside a transaction. But no transaction handler was configured." unless handler
 
-          handler.transaction { use_case_object.send(method_name) }
+          handler.transaction { entry_point_object.send(method_name) }
         else
-          use_case_object.send(method_name)
+          entry_point_object.send(method_name)
         end
       })
     end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -36,15 +36,15 @@ describe Caze do
     module Dummy
       include Caze
 
-      define_use_cases the_answer: DummyUseCase,
-                       the_answer_for: DummyUseCaseWithParam
+      define_entry_points the_answer: DummyUseCase,
+                          the_answer_for: DummyUseCaseWithParam
     end
   end
 
   let(:use_case) { DummyUseCase }
   let(:app) { Dummy }
 
-  describe '.define_use_cases' do
+  describe '.define_entry_points' do
     it 'delegates the use case message to the use case' do
       allow(use_case).to receive(:the_answer)
       app.the_answer

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -36,15 +36,15 @@ describe Caze do
     module Dummy
       include Caze
 
-      define_entry_points the_answer: DummyUseCase,
-                          the_answer_for: DummyUseCaseWithParam
+      define_use_cases the_answer: DummyUseCase,
+                       the_answer_for: DummyUseCaseWithParam
     end
   end
 
   let(:use_case) { DummyUseCase }
   let(:app) { Dummy }
 
-  describe '.define_entry_points' do
+  describe '.define_use_cases' do
     it 'delegates the use case message to the use case' do
       allow(use_case).to receive(:the_answer)
       app.the_answer

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -36,8 +36,9 @@ describe Caze do
     module Dummy
       include Caze
 
-      define_use_cases the_answer: DummyUseCase,
-                       the_answer_for: DummyUseCaseWithParam
+      define_use_cases the_answer:                    { use_case: DummyUseCase },
+                       the_answer_for:                { use_case: DummyUseCaseWithParam },
+                       the_answer_within_transaction: { use_case: DummyUseCase, within_transaction: true }
     end
   end
 
@@ -55,6 +56,35 @@ describe Caze do
         expect(app.the_answer_for('the meaning of life', priority: :high)).to eql([:high, 42])
       end
     end
+
+    context 'using transaction' do
+      context 'when there is a transaction method' do
+        let(:transaction_handler) { double(:transaction_handler) }
+
+        before do
+          app.transaction_handler = transaction_handler
+        end
+
+        it 'uses the transaction handler' do
+          expect(transaction_handler).to receive(:transaction)
+          app.the_answer_within_transaction
+        end
+      end
+
+      #context 'when there is no transaction method defined' do
+        #before do
+          #use_case.export :the_answer,
+                                      #as: :the_answer_with_transaction,
+                                      #use_transaction: true
+        #end
+
+        #it 'raises an exception' do
+          #expect {
+            #use_case.the_answer_with_transaction
+          #}.to raise_error(/This action should be executed inside a transaction/)
+        #end
+      #end
+    end
   end
 
   describe '.export' do
@@ -69,41 +99,6 @@ describe Caze do
 
       it 'defines an entry point with another name' do
         expect(use_case).to respond_to(:universal_answer)
-      end
-    end
-
-
-    context 'using transaction' do
-      context 'when there is a transaction method' do
-        let(:transaction_handler) do
-          double(:transaction_handler)
-        end
-
-        before do
-          app.transaction_handler = transaction_handler
-          use_case.export :the_answer,
-                                      as: :the_answer_with_transaction,
-                                      use_transaction: true
-        end
-
-        it 'uses the transaction handler' do
-          expect(transaction_handler).to receive(:transaction)
-          use_case.the_answer_with_transaction
-        end
-      end
-
-      context 'when there is no transaction method defined' do
-        before do
-          use_case.export :the_answer,
-                                      as: :the_answer_with_transaction,
-                                      use_transaction: true
-        end
-
-        it 'raises an exception' do
-          expect {
-            use_case.the_answer_with_transaction
-          }.to raise_error(/This action should be executed inside a transaction/)
-        end
       end
     end
   end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -36,9 +36,9 @@ describe Caze do
     module Dummy
       include Caze
 
-      define_use_cases the_answer:                    { use_case: DummyUseCase },
-                       the_answer_for:                { use_case: DummyUseCaseWithParam },
-                       the_answer_within_transaction: { use_case: DummyUseCase, within_transaction: true }
+      define_use_case :the_answer, DummyUseCase
+      define_use_case :the_answer_for, DummyUseCaseWithParam
+      define_use_case :the_transactional_answer, DummyUseCase, transactional: true
     end
   end
 
@@ -67,23 +67,17 @@ describe Caze do
 
         it 'uses the transaction handler' do
           expect(transaction_handler).to receive(:transaction)
-          app.the_answer_within_transaction
+          app.the_transactional_answer
         end
       end
 
-      #context 'when there is no transaction method defined' do
-        #before do
-          #use_case.export :the_answer,
-                                      #as: :the_answer_with_transaction,
-                                      #use_transaction: true
-        #end
-
-        #it 'raises an exception' do
-          #expect {
-            #use_case.the_answer_with_transaction
-          #}.to raise_error(/This action should be executed inside a transaction/)
-        #end
-      #end
+      context 'when there is no transaction method defined' do
+        it 'raises an exception' do
+          expect {
+            app.the_transactional_answer
+          }.to raise_error(/This action should be executed inside a transaction/)
+        end
+      end
     end
   end
 

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -12,7 +12,7 @@ describe Caze do
     class DummyUseCase
       include Caze
 
-      define_entry_point :the_answer
+      export :the_answer
 
       def the_answer
         42
@@ -22,7 +22,7 @@ describe Caze do
     class DummyUseCaseWithParam
       include Caze
 
-      define_entry_point :the_answer_for
+      export :the_answer_for
 
       def initialize(question, priority: :low)
         @priority = priority
@@ -57,14 +57,14 @@ describe Caze do
     end
   end
 
-  describe '.define_entry_point' do
+  describe '.export' do
     it 'defines a class method' do
       expect(use_case).to respond_to(:the_answer)
     end
 
     context 'using the flag `as`' do
       before do
-        use_case.define_entry_point :the_answer, as: :universal_answer
+        use_case.export :the_answer, as: :universal_answer
       end
 
       it 'defines an entry point with another name' do
@@ -81,7 +81,7 @@ describe Caze do
 
         before do
           app.transaction_handler = transaction_handler
-          use_case.define_entry_point :the_answer,
+          use_case.export :the_answer,
                                       as: :the_answer_with_transaction,
                                       use_transaction: true
         end
@@ -94,7 +94,7 @@ describe Caze do
 
       context 'when there is no transaction method defined' do
         before do
-          use_case.define_entry_point :the_answer,
+          use_case.export :the_answer,
                                       as: :the_answer_with_transaction,
                                       use_transaction: true
         end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -36,16 +36,16 @@ describe Caze do
     module Dummy
       include Caze
 
-      define_use_case :the_answer, DummyUseCase
-      define_use_case :the_answer_for, DummyUseCaseWithParam
-      define_use_case :the_transactional_answer, DummyUseCase, transactional: true
+      has_use_case :the_answer, DummyUseCase
+      has_use_case :the_answer_for, DummyUseCaseWithParam
+      has_use_case :the_transactional_answer, DummyUseCase, transactional: true
     end
   end
 
   let(:use_case) { DummyUseCase }
   let(:app) { Dummy }
 
-  describe '.define_use_cases' do
+  describe '.has_use_case' do
     it 'delegates the use case message to the use case' do
       allow(use_case).to receive(:the_answer)
       app.the_answer


### PR DESCRIPTION
This PR renames the main methods of this DSL, the goal is to make them easier to remember and to avoid ambiguity. 

So instead of `define_use_cases`:

```ruby
has_use_case :sum, UseCases::Sum
```

Also the transaction option was moved to the main DSL:

```ruby
has_use_case :sum, UseCases::Sum, transactional: true
```

The `define_entry_point` was renamed to `export`, export means create a class method version of an instance method. 

```ruby
export :sum, as: :execute
```