### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Instead of doing this:
 ```ruby
 module Project
   def self.sum(x, y)
-    UseCases::Sum.execute(x, y)
+    UseCases::Sum.sum(x, y)
   end
 
   def self.subtract(x, y)
-    UseCases::Subtract.execute(x, y)
+    UseCases::Subtract.substract(x, y)
   end
 end
 ```
@@ -61,7 +61,7 @@ Inside the use case classes you can use the `.export` method, so in the `UseCase
 module Project
   module UseCases
     class Sum
-      def self.execute(x ,y)
+      def self.sum(x ,y)
         new(x,y).foo
       end
 
@@ -86,7 +86,7 @@ module Project
     class Foo
       include Caze
 
-      export :sum, as: :execute
+      export :sum
 
       def initialize(x, y)
         @x = x

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -21,7 +21,7 @@ module Caze
 
           handler.transaction { use_case_class.send(use_case_name, *args) }
         else
-          use_case_class.send(use_case_name, *args)
+          use_case_class.send('execute', *args)
         end
       })
     end

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -21,7 +21,7 @@ module Caze
 
           handler.transaction { use_case_class.send(use_case_name, *args) }
         else
-          use_case_class.send('execute', *args)
+          use_case_class.send( use_case_name, *args)
         end
       })
     end

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -19,9 +19,9 @@ module Caze
 
           raise NoTransactionMethodError, "This action should be executed inside a transaction. But no transaction handler was configured." unless handler
 
-          handler.transaction { use_case_class.send(use_case_name, *args) }
+          handler.transaction { use_case_class.send('execute', *args) }
         else
-          use_case_class.send( use_case_name, *args)
+          use_case_class.send('execute', *args)
         end
       })
     end


### PR DESCRIPTION
Hi! The gem's README doesn't match its behavior, I guess it needs an update! Or we can send 'execute' message instead of 'use_case_name' in lib/caze.rb, so the README will be valid.