### PR TITLE
Accept use case class definition as string or symbol

### DIFF
--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -10,20 +10,25 @@ module Caze
   module ClassMethods
     attr_accessor :transaction_handler
 
-    def has_use_case(use_case_name, use_case_class, options = {})
-      transactional  = options.fetch(:transactional) { false }
+    def has_use_case(use_case_name, use_case_class_or_stringish, options = {})
+      transactional = options.fetch(:transactional) { false }
 
-      define_singleton_method(use_case_name, Proc.new { |*args|
+      define_singleton_method(use_case_name, Proc.new do |*args|
+        use_case_class = get_use_case_class(use_case_class_or_stringish)
+
         if transactional
           handler = self.transaction_handler
 
-          raise NoTransactionMethodError, "This action should be executed inside a transaction. But no transaction handler was configured." unless handler
+          unless handler
+            raise NoTransactionMethodError,
+              "This action should be executed inside a transaction. But no transaction handler was configured."
+          end
 
           handler.transaction { use_case_class.send(use_case_name, *args) }
         else
           use_case_class.send(use_case_name, *args)
         end
-      })
+      end)
     end
 
     def export(method_name, options = {})
@@ -33,6 +38,16 @@ module Caze
         use_case_object = args.empty? ? new : new(*args)
         use_case_object.send(method_name)
       })
+    end
+
+    private
+
+    def get_use_case_class(use_case_class_or_stringish)
+      if use_case_class_or_stringish.respond_to?(:upcase)
+        return Object.const_get(use_case_class_or_stringish)
+      end
+
+      use_case_class_or_stringish
     end
   end
 end

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -10,11 +10,11 @@ module Caze
   module ClassMethods
     attr_accessor :transaction_handler
 
-    def has_use_case(use_case_name, use_case_class_or_stringish, options = {})
+    def has_use_case(use_case_name, use_case_class, options = {})
       transactional = options.fetch(:transactional) { false }
 
       define_singleton_method(use_case_name, Proc.new do |*args|
-        use_case_class = get_use_case_class(use_case_class_or_stringish)
+        use_case = get_use_case_class(use_case_class)
 
         if transactional
           handler = self.transaction_handler
@@ -24,9 +24,9 @@ module Caze
               "This action should be executed inside a transaction. But no transaction handler was configured."
           end
 
-          handler.transaction { use_case_class.send(use_case_name, *args) }
+          handler.transaction { use_case.send(use_case_name, *args) }
         else
-          use_case_class.send(use_case_name, *args)
+          use_case.send(use_case_name, *args)
         end
       end)
     end
@@ -42,12 +42,12 @@ module Caze
 
     private
 
-    def get_use_case_class(use_case_class_or_stringish)
-      if use_case_class_or_stringish.respond_to?(:upcase)
-        return Object.const_get(use_case_class_or_stringish)
+    def get_use_case_class(use_case_class)
+      if use_case_class.respond_to?(:upcase)
+        return Object.const_get(use_case_class)
       end
 
-      use_case_class_or_stringish
+      use_case_class
     end
   end
 end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -14,6 +14,8 @@ describe Caze do
 
       export :the_answer
       export :the_answer, as: :the_transactional_answer
+      export :the_answer, as: :the_answer_by_another_entry_point
+      export :the_answer, as: :the_universal_answer
 
       def the_answer
         42
@@ -38,6 +40,8 @@ describe Caze do
       include Caze
 
       has_use_case :the_answer, DummyUseCase
+      has_use_case :the_answer_by_another_entry_point, 'DummyUseCase'
+      has_use_case :the_universal_answer, :DummyUseCase
       has_use_case :the_answer_for, DummyUseCaseWithParam
       has_use_case :the_transactional_answer, DummyUseCase, transactional: true
     end
@@ -47,14 +51,31 @@ describe Caze do
   let(:app) { Dummy }
 
   describe '.has_use_case' do
-    it 'delegates the use case message to the use case' do
-      allow(use_case).to receive(:the_answer)
+    it 'delegates the message to the use case' do
+      expect(use_case).to receive(:the_answer)
+
       app.the_answer
     end
 
     context 'when method has params' do
       it 'calls the method with the right params' do
         expect(app.the_answer_for('the meaning of life', priority: :high)).to eql([:high, 42])
+      end
+    end
+
+    context 'when use case class is declared as string' do
+      it 'delegates the message to the use case' do
+        expect(use_case).to receive(:the_answer_by_another_entry_point)
+
+        app.the_answer_by_another_entry_point
+      end
+    end
+
+    context 'when use case class is declared as symbol' do
+      it 'delegates the message to the use case' do
+        expect(use_case).to receive(:the_universal_answer)
+
+        app.the_universal_answer
       end
     end
 
@@ -68,6 +89,7 @@ describe Caze do
 
         it 'uses the transaction handler' do
           expect(transaction_handler).to receive(:transaction).and_yield
+
           app.the_transactional_answer
         end
       end


### PR DESCRIPTION
This enables the users to define use cases as string (or symbol) in
order to avoid problems as constant missing in Rails engines entry
points, or things that are loaded dynamically.

Closes #6.