### PR TITLE
Exceptions/interceptor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- Add support to raise erros with the use case name.
+- Add support to raise errors with the use case name.
 
 ## [0.1.0] - 2015-10-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.1.1] - 2015-10-30
+
+### Added
+
+- Add support to raise erros with the use case name.
+
 ## [0.1.0] - 2015-10-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,14 +60,14 @@ and rollback if necessary.
 
 ## Using exception interceptor
 
-You can use the exception interceptor in your use case by providing a `intercept_exceptions`
-in your module in order to intercept errors and write the use case name on it.
+You can use the raise use case exception in order to know the use case name when an
+error happen.
 
 While declaring which use case your app has, you can set the option
-`intercept_exceptions` to `true`.
+`raise_use_case_exception` to `true`.
 
 ```ruby
-has_use_case :say_my_name, UseCases::SayMyName, intercept_exceptions: true
+has_use_case :say_my_name, UseCases::SayMyName, raise_use_case_exception: true
 ```
 
 It should intercept yours exceptions and write the use case name on it following the

--- a/README.md
+++ b/README.md
@@ -57,6 +57,22 @@ Note that the transaction handler must implement `#transaction` and
 return the value inside the block. It will also be responsible for handle errors
 and rollback if necessary.
 
+
+## Using exception interceptor
+
+You can use the exception interceptor in your use case by providing a `intercept_exceptions`
+in your module in order to intercept errors and write the use case name on it.
+
+While declaring which use case your app has, you can set the option
+`intercept_exceptions` to `true`.
+
+```ruby
+has_use_case :say_my_name, UseCases::SayMyName, intercept_exceptions: true
+```
+
+It should intercept yours exceptions and write the use case name on it following the
+pattern: `SayMyName: This is you error message Heisenberg`
+
 ## Exporting instance methods as class methods
 
 Inside the use case classes you can use the `.export` method, so in the `UseCases::Sum` instead of this:

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -13,7 +13,7 @@ module Caze
 
     def has_use_case(use_case_name, use_case_class, options = {})
       transactional = options.fetch(:transactional) { false }
-      intercept_exceptions = options.fetch(:intercept_exceptions) { false }
+      raise_use_case_exception = options.fetch(:raise_use_case_exception) { false }
 
       define_singleton_method(use_case_name, Proc.new do |*args|
         use_case = get_use_case_class(use_case_class)
@@ -32,7 +32,7 @@ module Caze
             use_case.send(use_case_name, *args)
           end
         rescue => e
-          if intercept_exceptions
+          if raise_use_case_exception
             raise UseCaseError.new(e).exception("#{use_case_class}: #{e.message}")
           else
             raise e

--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -5,6 +5,7 @@ require 'active_support/core_ext/module/delegation'
 
 module Caze
   class NoTransactionMethodError < StandardError; end
+  class UseCaseError < StandardError; end
   extend ActiveSupport::Concern
 
   module ClassMethods
@@ -32,7 +33,7 @@ module Caze
           end
         rescue => e
           if intercept_exceptions
-            raise "#{use_case_class}: #{e.message}"
+            raise UseCaseError.new(e).exception("#{use_case_class}: #{e.message}")
           else
             raise e
           end

--- a/lib/caze/version.rb
+++ b/lib/caze/version.rb
@@ -1,3 +1,3 @@
 module Caze
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -50,9 +50,9 @@ describe Caze do
       has_use_case :the_universal_answer, :DummyUseCase
       has_use_case :the_answer_for, DummyUseCaseWithParam
       has_use_case :the_transactional_answer, DummyUseCase, transactional: true
-      has_use_case :the_question, DummyUseCase, intercept_exceptions: true
+      has_use_case :the_question, DummyUseCase, raise_use_case_exception: true
       has_use_case :the_transactional_and_intercepted_answer, DummyUseCase, transactional: true,
-                                                                            intercept_exceptions: true
+                                                                            raise_use_case_exception: true
     end
   end
 

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -16,6 +16,7 @@ describe Caze do
       export :the_answer, as: :the_transactional_answer
       export :the_answer, as: :the_answer_by_another_entry_point
       export :the_answer, as: :the_universal_answer
+      export :the_answer, as: :the_transactional_and_intercepted_answer
       export :the_question
 
       def the_answer
@@ -50,6 +51,8 @@ describe Caze do
       has_use_case :the_answer_for, DummyUseCaseWithParam
       has_use_case :the_transactional_answer, DummyUseCase, transactional: true
       has_use_case :the_question, DummyUseCase, intercept_exceptions: true
+      has_use_case :the_transactional_and_intercepted_answer, DummyUseCase, transactional: true,
+                                                                            intercept_exceptions: true
     end
   end
 
@@ -109,12 +112,22 @@ describe Caze do
       end
     end
 
-    context 'using exceptions' do
+    context 'using exception' do
       context 'when the use case raises an exception' do
         it 'shows the use case name' do
           expect {
             app.the_question
           }.to raise_error('DummyUseCase: You did not say yet.')
+        end
+      end
+    end
+
+    context 'using exception and transaction' do
+      context 'when the use case raises the transaction exception' do
+        it 'shows the use case name' do
+          expect {
+            app.the_transactional_and_intercepted_answer
+          }.to raise_error(/DummyUseCase: This action should be executed inside a transaction/)
         end
       end
     end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -5,7 +5,7 @@ describe Caze do
   before do
     # Removing constant definitions if they exist
     # This avoids state to be permanent through tests
-    [:DummyUseCase, :DummyUseCaseWithParam, :Dummy, :ExceptionRaiser].each do |const|
+    [:DummyUseCase, :DummyUseCaseWithParam, :Dummy].each do |const|
       Object.send(:remove_const, const) if Object.constants.include?(const)
     end
 

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -5,7 +5,7 @@ describe Caze do
   before do
     # Removing constant definitions if they exist
     # This avoids state to be permanent through tests
-    [:DummyUseCase, :DummyUseCaseWithParam, :Dummy].each do |const|
+    [:DummyUseCase, :DummyUseCaseWithParam, :Dummy, :ExceptionRaiser].each do |const|
       Object.send(:remove_const, const) if Object.constants.include?(const)
     end
 
@@ -16,9 +16,14 @@ describe Caze do
       export :the_answer, as: :the_transactional_answer
       export :the_answer, as: :the_answer_by_another_entry_point
       export :the_answer, as: :the_universal_answer
+      export :the_question
 
       def the_answer
         42
+      end
+
+      def the_question
+        raise 'You did not say yet.'
       end
     end
 
@@ -44,6 +49,7 @@ describe Caze do
       has_use_case :the_universal_answer, :DummyUseCase
       has_use_case :the_answer_for, DummyUseCaseWithParam
       has_use_case :the_transactional_answer, DummyUseCase, transactional: true
+      has_use_case :the_question, DummyUseCase, intercept_exceptions: true
     end
   end
 
@@ -99,6 +105,16 @@ describe Caze do
           expect {
             app.the_transactional_answer
           }.to raise_error(/This action should be executed inside a transaction/)
+        end
+      end
+    end
+
+    context 'using exceptions' do
+      context 'when the use case raises an exception' do
+        it 'shows the use case name' do
+          expect {
+            app.the_question
+          }.to raise_error('DummyUseCase: You did not say yet.')
         end
       end
     end


### PR DESCRIPTION
This PR adds an interceptor to handle exceptions raised in order to add the use case name on it.

card: https://trello.com/c/hgGXKeB5/3100-brokerservice-specific-error-for-each-use-case
It' part of the card, because there are some code to be done into the app.