### PR TITLE
Fix raise of use case error

### DIFF
--- a/lib/caze.rb
+++ b/lib/caze.rb
@@ -68,10 +68,11 @@ module Caze
 
       error_class = use_case.const_set(demodulized_error_class, base_class)
 
-      error_instance = error_class.new(error.message)
-      error_instance.set_backtrace(error.backtrace)
+      error.define_singleton_method(:class) do
+        error_class
+      end
 
-      raise error_instance
+      raise error
     end
   end
 end

--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -2,13 +2,19 @@ require 'spec_helper'
 require 'caze'
 
 describe Caze do
+
   before do
     # Removing constant definitions if they exist
     # This avoids state to be permanent through tests
-    [:DummyUseCase, :DummyUseCaseWithParam, :Dummy, :DummyUseCaseTest].each do |const|
+    [:DummyUseCase,
+     :DummyUseCaseWithParam,
+     :Dummy,
+     :DummyError,
+     :DummyUseCaseTest].each do |const|
       Object.send(:remove_const, const) if Object.constants.include?(const)
     end
 
+    class DummyError < StandardError; end
     class DummyUseCase
       include Caze
 
@@ -48,7 +54,7 @@ describe Caze do
       export :the_question
 
       def the_question
-        raise 'We do not know the question'
+        raise DummyError.new("We don't know the question")
       end
     end
 
@@ -134,7 +140,7 @@ describe Caze do
         it 'raises with the namespace of the use case' do
           expect {
             namespaced_use_case.the_question
-          }.to raise_error(DummyUseCaseTest::RuntimeError)
+          }.to raise_error(DummyUseCaseTest::DummyError)
         end
       end
     end


### PR DESCRIPTION
This version does not instantiate a new error. Instead, it modifies the
class method of the error object.

This is needed in order to better represent the error as a nested error
from the use case, and to avoid have to instantiate the error class again. Sometimes this instantiation expects a different object other than string/error.
