### PR TITLE
Rewrite how we wrap exceptions from use cases

### DIFF
--- a/spec/caze_spec.rb
+++ b/spec/caze_spec.rb
@@ -140,7 +140,11 @@ describe Caze do
         it 'raises with the namespace of the use case' do
           expect {
             namespaced_use_case.the_question
-          }.to raise_error(DummyUseCaseTest::DummyError)
+          }.to raise_error do |error|
+            expect(error).to be_a(DummyUseCaseTest::DummyError)
+            expect(error.cause).to be_a(::DummyError)
+            expect(error.backtrace.first).to match(/in `the_question'/)
+          end
         end
       end
     end


### PR DESCRIPTION
The previous implementation would define the same constant on every invocation and the `class` override does not work as expected, but from now on:

* No more warnings from reassigns or mismatched lookups.
* All wrapped exceptions will inherit directly from `StandardError`,
 not the exception that was raised, avoiding constructor pitfalls.
* The original exception can be accessed via `e.cause`.
* Our internal `NoTransactionMethodError` wont be wrapped anymore.
* We can test that the backtrace is generated as expected.